### PR TITLE
Adjust typoDescender formula so result is a negative number?

### DIFF
--- a/VerticalMetrics/README.md
+++ b/VerticalMetrics/README.md
@@ -120,8 +120,8 @@ A new Latin family has the following qualities:
 
 1. Set the default values, following the schema above:
 
-    - typoAscender = `965`. (`UPM * 1.2 - CapsHeight) / 2 + CapsHeight` which is greater than Agrave, perfect.)
-    - typoDescender = `-235`. (`UPM * 1.2 - CapsHeight) / -2` which is equal to deepest letterform)
+    - typoAscender = `965` (`(UPM * 1.2 - CapsHeight) / 2 + CapsHeight` which is greater than Agrave, perfect.)
+    - typoDescender = `-235` (`-(UPM * 1.2 - CapsHeight) / 2` which is equal to deepest letterform)
     - typoLineGap = `0`
     - hheaAscender = `965` (typoAscender)
     - hheaDescender = `-235` (typoDescender)


### PR DESCRIPTION
The `typoDescender` `(UPM * 1.2 - CapsHeight) / 2)` formula doesn't produce a negative number, so I thought this might be less confusing: `(UPM * 1.2 - CapsHeight) / -2)`

This is subjective and there might be some reason to leave it as is I don't know about, so please close or ignore this PR if that is the case, this just makes more sense to me. Thanks! 